### PR TITLE
add support for linux version > 2.6.36 in /scull module

### DIFF
--- a/scull/main.c
+++ b/scull/main.c
@@ -27,6 +27,7 @@
 #include <linux/fcntl.h>	/* O_ACCMODE */
 #include <linux/seq_file.h>
 #include <linux/cdev.h>
+#include <linux/version.h>
 
 #include <asm/system.h>		/* cli(), *_flags */
 #include <asm/uaccess.h>	/* copy_*_user */
@@ -647,7 +648,11 @@ int scull_init_module(void)
 	for (i = 0; i < scull_nr_devs; i++) {
 		scull_devices[i].quantum = scull_quantum;
 		scull_devices[i].qset = scull_qset;
+#if LINUX_VERSION_CODE > KERNEL_VERSION(2, 6, 36) && !defined(init_MUTEX)
+		sema_init(&scull_devices[i].sem, 1);
+#else
 		init_MUTEX(&scull_devices[i].sem);
+#endif
 		scull_setup_cdev(&scull_devices[i], i);
 	}
 

--- a/scull/pipe.c
+++ b/scull/pipe.c
@@ -28,6 +28,7 @@
 #include <linux/cdev.h>
 #include <linux/sched.h>
 #include <asm/uaccess.h>
+#include <linux/version.h>
 
 #include "scull.h"		/* local definitions */
 
@@ -363,7 +364,11 @@ int scull_p_init(dev_t firstdev)
 	for (i = 0; i < scull_p_nr_devs; i++) {
 		init_waitqueue_head(&(scull_p_devices[i].inq));
 		init_waitqueue_head(&(scull_p_devices[i].outq));
+#if LINUX_VERSION_CODE > KERNEL_VERSION(2, 6, 36) && !defined(init_MUTEX)
+		sema_init(&scull_p_devices[i].sem, 1);
+#else
 		init_MUTEX(&scull_p_devices[i].sem);
+#endif
 		scull_p_setup_cdev(scull_p_devices + i, i);
 	}
 #ifdef SCULL_DEBUG


### PR DESCRIPTION
1. replace init_MUTEX with sema_init for version greater than 2.6.36
2. replace SPIN_LOCK_UNLOCKED with __SPIN_LOCK_UNLOCKED(x) for version greater or equals to 3.0.0

Above passed my test on ubuntu 11.10, whose kernel version is 3.0.0.